### PR TITLE
fix: ignore isArray in lodash rules

### DIFF
--- a/lodash.js
+++ b/lodash.js
@@ -4,7 +4,7 @@ module.exports = {
   extends: ["plugin:lodash/recommended"],
   plugins: ["lodash"],
   rules: {
-    "lodash/prefer-lodash-method": [2, {ignoreObjects: ["wrapper", "component"]}],
+    "lodash/prefer-lodash-method": [2, {ignoreObjects: ["wrapper", "component"], ignoreMethods: ["isArray"]}],
     "lodash/import-scope": 0,
   },
 };


### PR DESCRIPTION
Array.isArray is supported for IE9 and above and works better with
flow refinement for some versions.